### PR TITLE
プレイ画面のレスポンシブ対応

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-icons": "^1.3.0",
+        "@radix-ui/react-progress": "^1.1.0",
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-toast": "^1.2.1",
         "@shadcn/ui": "^0.0.4",
@@ -1462,6 +1463,30 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.0.tgz",
+      "integrity": "sha512-aSzvnYpP725CROcxAOEBVZZSIQVQdHgBr2QQFKySsaD14u8dNT0batuXI+AAGDdAHfXH8rbnHmjYFqVJ21KkRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@radix-ui/react-icons": "^1.3.0",
+    "@radix-ui/react-progress": "^1.1.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-toast": "^1.2.1",
     "@shadcn/ui": "^0.0.4",

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -4,7 +4,8 @@ import styled from 'styled-components';
 import Image from 'next/image';
 import { questions } from '../data/questions';
 import { useQuestions } from '@/usecases/useQuestions';
-import ProgressBarWithCount from '@/components/features/ProgressBarWithCount';
+import { ProgressBarWithCount } from '@/components/features/ProgressBarWithCount';
+import { BREAKPOINTS } from '@/components/Responsive';
 
 //質問回答画面
 function Play() {
@@ -18,59 +19,63 @@ function Play() {
   const totalQuestions = questions.length; //総質問数
 
   const progress =
-    (currentQuestionIndex / totalQuestions) * 100; //プログレス
+    ((currentQuestionIndex + 1) / totalQuestions) * 100;
 
   return (
-    <div>
-      <Wrapper>
-        <QuestionArea>
-          <ImageWrapper>
-            <Image
-              src="/static.jpeg"
-              width={300}
-              height={200}
-              alt="sample"
-            />
-          </ImageWrapper>
-          <Question>{currentQuestion.question}</Question>
-        </QuestionArea>
-        <Buttons>
-          <BadButton onClick={onClickBadHandler}>
-            Bad
-          </BadButton>
-          <GoodButton onClick={onClickGoodHandler}>
-            Good
-          </GoodButton>
-        </Buttons>
-        <ProgressBarWithCount
-          progress={progress}
-          currentQuestion={currentQuestionIndex}
-          totalQuestions={totalQuestions}
-        />
-      </Wrapper>
-    </div>
+    <Wrapper>
+      <ProgressBarWithCount
+        progress={progress}
+        currentQuestionIndex={currentQuestionIndex}
+        totalQuestions={totalQuestions}
+      />
+      <QuestionArea>
+        <ImageWrapper>
+          <Image
+            src="/static.jpeg"
+            width={300}
+            height={200}
+            alt="sample"
+          />
+        </ImageWrapper>
+        <Question>{currentQuestion.question}</Question>
+      </QuestionArea>
+      <Buttons>
+        <BadButton onClick={onClickBadHandler}>
+          Bad
+        </BadButton>
+        <GoodButton onClick={onClickGoodHandler}>
+          Good
+        </GoodButton>
+      </Buttons>
+    </Wrapper>
   );
 }
 
 export default Play;
 
 const Wrapper = styled.div`
-  background-image: url(/backgroundImage/questionBackground.png);
-  background-repeat: no-repeat;
+  background-image: url('/backgroundImage/questionBackground.png');
+  background-position: center;
   background-size: cover;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  min-height: 100vh;
+  height: 100vh;
+  width: 100%;
   padding: 60px;
+
+  @media screen and (max-width: ${BREAKPOINTS.SP}) {
+    padding: 30px;
+  }
 `;
 
 const QuestionArea = styled.div`
   background-color: #fff;
-  border-radius: 10px;
+  border-radius: 27px;
   padding: 40px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  border-top: 10px solid #cff4f9;
+  border-bottom: 10px solid #cff4f9;
   text-align: center;
   width: 100%;
   max-width: 1000px;
@@ -94,14 +99,22 @@ const Question = styled.p`
   font-size: 1.8rem;
   color: #333;
   padding-top: 40px;
+
+  @media screen and (max-width: ${BREAKPOINTS.SP}) {
+    font-size: 1.4rem;
+  }
 `;
 
 const Buttons = styled.div`
   display: flex;
-  gap: 150px;
+  width: 100%;
+  justify-content: space-around;
   margin-top: 50px;
 `;
 const GoodButton = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
   color: #fff;
   font-weight: 800;
   background-color: #3cb371;
@@ -115,9 +128,18 @@ const GoodButton = styled.button`
   &:hover {
     background-color: #2e8b57;
   }
+
+  @media screen and (max-width: ${BREAKPOINTS.SP}) {
+    width: 64px;
+    height: 64px;
+    font-size: 1rem;
+  }
 `;
 
 const BadButton = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
   color: #fff;
   font-weight: 800;
   background-color: #dc143c;
@@ -130,5 +152,11 @@ const BadButton = styled.button`
   transition: background-color 0.8s;
   &:hover {
     background-color: #a10b2d;
+  }
+
+  @media screen and (max-width: ${BREAKPOINTS.SP}) {
+    width: 64px;
+    height: 64px;
+    font-size: 1rem;
   }
 `;

--- a/src/components/features/Header/index.tsx
+++ b/src/components/features/Header/index.tsx
@@ -71,6 +71,7 @@ const Container = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  z-index: 1000;
 `;
 
 const ImageWrapper = styled.div`

--- a/src/components/features/ProgressBarWithCount.tsx
+++ b/src/components/features/ProgressBarWithCount.tsx
@@ -1,58 +1,37 @@
-import React from 'react';
 import styled from 'styled-components';
+import { Progress } from '@/components/ui/progress';
 
+type Props = {
+  progress: number; // プログレスの割合 (0-100)
+  currentQuestionIndex: number; // 現在の質問番号
+  totalQuestions: number; // 総質問数
+};
+
+export const ProgressBarWithCount = ({
+  progress,
+  currentQuestionIndex,
+  totalQuestions,
+}: Props) => {
+  return (
+    <ProgressContainer>
+      <QuestionCount>
+        {currentQuestionIndex + 1}/{totalQuestions}
+      </QuestionCount>
+      <Progress value={progress} />
+    </ProgressContainer>
+  );
+};
 
 const ProgressContainer = styled.div`
   display: flex;
   align-items: center;
   flex-direction: column;
   margin-top: 10px;
-  position: relative;
   width: 50%;
 `;
 
-
-const ProgressBarContainer = styled.div`
-  width: 100%;
-  background-color: #e0e0df;
-  border-radius: 10px;
-  overflow: hidden;
-  margin-right: 10px; 
-  margin-top: 10px;
-  position: relative;
-`;
-
-
-const Progress = styled.div<{ progress: number }>`
-  width: ${({ progress }) => progress}%;
-  height: 20px;
-  background-color: #76c7c0;
-  transition: width 0.5s ease;
-`;
-
-
-const QuestionCount = styled.span`
-  font-size: 16px;
+const QuestionCount = styled.p`
+  font-size: 1.8rem;
   font-weight: bold;
+  margin: 10px 0;
 `;
-
-type ProgressBarProps = {
-  progress: number; // プログレスの割合 (0-100)
-  currentQuestion: number; // 現在の質問番号
-  totalQuestions: number; // 総質問数
-};
-
-const ProgressBarWithCount: React.FC<ProgressBarProps> = ({ progress, currentQuestion, totalQuestions }) => {
-  return (
-    <ProgressContainer>
-      <ProgressBarContainer>
-        <Progress progress={progress} />
-      </ProgressBarContainer>
-      <QuestionCount>
-        {currentQuestion}/{totalQuestions}
-      </QuestionCount>
-    </ProgressContainer>
-  );
-};
-
-export default ProgressBarWithCount;

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import * as React from 'react';
+import * as ProgressPrimitive from '@radix-ui/react-progress';
+
+import { cn } from '@/lib/utils';
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<
+    typeof ProgressPrimitive.Root
+  >
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      'relative h-4 w-full overflow-hidden rounded-full bg-secondary',
+      className
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className="h-full w-full flex-1 bg-[#76c7c0] transition-all"
+      style={{
+        transform: `translateX(-${100 - (value || 0)}%)`,
+      }}
+    />
+  </ProgressPrimitive.Root>
+));
+Progress.displayName = ProgressPrimitive.Root.displayName;
+
+export { Progress };

--- a/src/usecases/useQuestions.ts
+++ b/src/usecases/useQuestions.ts
@@ -7,7 +7,7 @@ export const useQuestions = (questions: Question[]) => {
   const router = useRouter();
   // 現在の質問のインデックス
   const [currentQuestionIndex, setCurrentQuestionIndex] =
-    useState<number>(1);
+    useState<number>(0);
 
   const [scores, setScores] = useState<Scores>({
     E: 0,
@@ -24,6 +24,7 @@ export const useQuestions = (questions: Question[]) => {
   const currentQuestion = questions[currentQuestionIndex];
 
   const onClickGoodHandler = () => {
+    console.log('good');
     const updatedScores = { ...scores };
 
     currentQuestion.options.yes.forEach((option) => {


### PR DESCRIPTION
## 🖇 関連Issue

#60 

##  🎂 やったこと

- プレイ画面のレスポンシブ対応
- プログレスバーをshadcnコンポーネントに変更
- 質問文の表示計算ロジック修正
- ハンバーガーメニューのposition修正

| モバイル | PC |
| --- | --- |
| <img width="502" alt="image" src="https://github.com/user-attachments/assets/7e690ac2-69d9-4ac4-95f6-5d7f0f733204"> | <img width="1512" alt="image" src="https://github.com/user-attachments/assets/2cc9de7f-3364-48ce-85d4-9aeb81ac6605"> |
## ⛔ やってないこと

<!-- 今回スコープアウトしたこと -->
<!-- 不要ならセクションごと削除してください -->

## 💡 確認したこと

<!-- 実装者が自分で確認したこと -->

## 🏃‍♂️ その他

<!-- レビュワーに伝えたいことや感想など -->
