### PR TITLE
ページ遷移のアニメーション

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,17 +3,24 @@
 import React from 'react';
 import Link from 'next/link';
 import styled from 'styled-components';
-import Image from 'next/image';
 import { BREAKPOINTS } from '@/components/Responsive';
 import {
   Slideshow,
   Slide,
 } from '@/components/features/Slideshow';
+import { PageTransition } from '@/components/PageTransition';
+import { motion } from 'framer-motion';
 
 //indexページ
 export default function Home() {
   return (
-    <Wrapper>
+    <Wrapper
+      initial={PageTransition.initial}
+      animate={PageTransition.animate}
+      exit={PageTransition.exit}
+      variants={PageTransition.variants}
+      transition={PageTransition.transition}
+    >
       <Container>
         <ConceptText>
           あなたは<NoBreakText>どのタイプ？</NoBreakText>
@@ -45,7 +52,7 @@ export default function Home() {
   );
 }
 
-const Wrapper = styled.div`
+const Wrapper = styled(motion.div)`
   background-image: url('/backgroundImage/indexBackground.png');
   background-size: cover;
   background-position: center;

--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -8,6 +8,7 @@ import { ProgressBarWithCount } from '@/components/features/ProgressBarWithCount
 import { BREAKPOINTS } from '@/components/Responsive';
 import { motion } from 'framer-motion';
 import { useState } from 'react';
+import { PageTransition } from '@/components/PageTransition';
 
 //質問回答画面
 function Play() {
@@ -50,7 +51,13 @@ function Play() {
   };
 
   return (
-    <Wrapper>
+    <Wrapper
+      initial={PageTransition.initial}
+      animate={PageTransition.animate}
+      exit={PageTransition.exit}
+      variants={PageTransition.variants}
+      transition={PageTransition.transition}
+    >
       <ProgressBarWithCount
         progress={progress}
         currentQuestionIndex={currentQuestionIndex}
@@ -101,7 +108,7 @@ function Play() {
 
 export default Play;
 
-const Wrapper = styled.div`
+const Wrapper = styled(motion.div)`
   background-image: url('/backgroundImage/questionBackground.png');
   background-position: center;
   background-size: cover;

--- a/src/app/result/detail/page.tsx
+++ b/src/app/result/detail/page.tsx
@@ -6,6 +6,8 @@ import { SimpleSlider } from '@/components/features/SimpleSlider';
 import { useResult } from '@/usecases/useResult';
 import Loader from '@/components/features/Loader';
 import { ResultNothing } from '@/components/features/ResultNothing';
+import { PageTransition } from '@/components/PageTransition';
+import { motion } from 'framer-motion';
 
 const ResultDetail = () => {
   const { parsedScores, resultedId, loading, timeout } =
@@ -25,7 +27,13 @@ const ResultDetail = () => {
     return <ResultNothing />;
   }
   return (
-    <Wrapper>
+    <Wrapper
+      initial={PageTransition.initial}
+      animate={PageTransition.animate}
+      exit={PageTransition.exit}
+      variants={PageTransition.variants}
+      transition={PageTransition.transition}
+    >
       <SimpleSlider />
     </Wrapper>
   );
@@ -40,7 +48,7 @@ const LoadingWrapper = styled.div`
   height: 100vh;
 `;
 
-const Wrapper = styled.div`
+const Wrapper = styled(motion.div)`
   background-image: url('/backgroundImage/resultDetailBackground.png');
   background-size: cover;
   background-position: center;

--- a/src/app/result/list/page.tsx
+++ b/src/app/result/list/page.tsx
@@ -4,10 +4,18 @@ import styled from 'styled-components';
 import { BREAKPOINTS } from '@/components/Responsive';
 import { ResultCard } from '@/components/features/ResultCard';
 import { resultSections } from '@/app/data/resultSections';
+import { PageTransition } from '@/components/PageTransition';
+import { motion } from 'framer-motion';
 
 function ListResult() {
   return (
-    <Wrapper>
+    <Wrapper
+      initial={PageTransition.initial}
+      animate={PageTransition.animate}
+      exit={PageTransition.exit}
+      variants={PageTransition.variants}
+      transition={PageTransition.transition}
+    >
       <Title>診断結果一覧</Title>
       {resultSections.map((section, index) => (
         <SectionContent
@@ -33,7 +41,7 @@ function ListResult() {
 
 export default ListResult;
 
-const Wrapper = styled.div`
+const Wrapper = styled(motion.div)`
   display: flex;
   flex-direction: column;
 `;

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -10,6 +10,8 @@ import { BREAKPOINTS } from '@/components/Responsive';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
 import { ResultNothing } from '@/components/features/ResultNothing';
+import { PageTransition } from '@/components/PageTransition';
+import { motion } from 'framer-motion';
 
 // 診断結果ページ
 function List() {
@@ -34,7 +36,13 @@ function List() {
   }
 
   return (
-    <Wrapper>
+    <Wrapper
+      initial={PageTransition.initial}
+      animate={PageTransition.animate}
+      exit={PageTransition.exit}
+      variants={PageTransition.variants}
+      transition={PageTransition.transition}
+    >
       <BackgroundImage resultedId={resultedId}>
         <Title>診断結果</Title>
         <Container>
@@ -66,7 +74,7 @@ const LoadingWrapper = styled.div`
   height: 100vh;
 `;
 
-const Wrapper = styled.div``;
+const Wrapper = styled(motion.div)``;
 
 const Title = styled.h1`
   font-size: 2.8rem;

--- a/src/app/result/printer/page.tsx
+++ b/src/app/result/printer/page.tsx
@@ -18,6 +18,8 @@ import { usePrintDocument } from './hooks/printDocument';
 import { PrintButton } from '@/components/features/PrintButton';
 import Loader from '@/components/features/Loader';
 import { ResultNothing } from '@/components/features/ResultNothing';
+import { PageTransition } from '@/components/PageTransition';
+import { motion } from 'framer-motion';
 
 function ResultPrinter() {
   const {
@@ -93,7 +95,13 @@ function ResultPrinter() {
   }
 
   return (
-    <Container>
+    <Container
+      initial={PageTransition.initial}
+      animate={PageTransition.animate}
+      exit={PageTransition.exit}
+      variants={PageTransition.variants}
+      transition={PageTransition.transition}
+    >
       <Wrapper
         className="invoicePages"
         id="invoicePageOne"
@@ -155,7 +163,7 @@ const LoadingWrapper = styled.div`
   height: 100vh;
 `;
 
-const Container = styled.div`
+const Container = styled(motion.div)`
   position: relative;
 `;
 

--- a/src/components/PageTransition.tsx
+++ b/src/components/PageTransition.tsx
@@ -1,0 +1,13 @@
+const pageTransitionVariants = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1 },
+  exit: { opacity: 0 },
+};
+
+export const PageTransition = {
+  initial: 'initial',
+  animate: 'animate',
+  exit: 'exit',
+  variants: pageTransitionVariants,
+  transition: { duration: 0.6 },  
+};


### PR DESCRIPTION
## 🖇 関連Issue

#103 

##  🎂 やったこと

ページ遷移した際のアニメーションを追加
ホーム画面、プレイ画面、診断結果画面、診断結果詳細画面、診断結果一覧画面、プリント画面

## ⛔ やってないこと

<!-- 今回スコープアウトしたこと -->
<!-- 不要ならセクションごと削除してください -->

## 💡 確認したこと

<!-- 実装者が自分で確認したこと -->

## 🏃‍♂️ その他

<!-- レビュワーに伝えたいことや感想など -->
