### PR TITLE
質問画面のレイアウトずれ

### DIFF
--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -91,7 +91,7 @@ function Play() {
         <ImageWrapper>
           <Image
             src={currentQuestion.questionImage}
-            width={300}
+            width={200}
             height={200}
             alt={currentQuestion.questionAlt}
           />


### PR DESCRIPTION
## 🖇 関連Issue
#127 

##  🎂 やったこと

質問画面の画像の大きさを調整
<img width="521" alt="スクリーンショット 2024-09-16 19 21 35" src="https://github.com/user-attachments/assets/01711b49-f227-485f-bfed-fd77b2f26613">

<img width="737" alt="image" src="https://github.com/user-attachments/assets/5538c251-cd40-41bd-8142-7a4fab81af09">
<img width="1466" alt="image" src="https://github.com/user-attachments/assets/e6791e57-e597-40e8-8699-d85b176f3184">


## ⛔ やってないこと

<!-- 今回スコープアウトしたこと -->
<!-- 不要ならセクションごと削除してください -->

## 💡 確認したこと

<!-- 実装者が自分で確認したこと -->

## 🏃‍♂️ その他

<!-- レビュワーに伝えたいことや感想など -->
